### PR TITLE
fix: add more aria-*/role attributes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -73,6 +73,8 @@ Conforming user agents MUST implement the following IDL interface.
 
 <pre class="idl">
   interface mixin AutoARIAMixin {
+    attribute DOMString? autoRole;
+    attribute Element? autoAriaActiveDescendantElement;
     attribute DOMString? autoAriaAtomic;
     attribute DOMString? autoAriaAutoComplete;
     attribute DOMString? autoAriaBusy;
@@ -81,21 +83,28 @@ Conforming user agents MUST implement the following IDL interface.
     attribute DOMString? autoAriaColIndex;
     attribute DOMString? autoAriaColIndexText;
     attribute DOMString? autoAriaColSpan;
+    attribute FrozenArray<Element>? autoAriaControlsElements;
     attribute DOMString? autoAriaCurrent;
+    attribute FrozenArray<Element>? autoAriaDescribedByElements;
     attribute DOMString? autoAriaDescription;
+    attribute FrozenArray<Element>? autoAriaDetailsElements;
     attribute DOMString? autoAriaDisabled;
+    attribute Element? autoAriaErrorMessageElement;
     attribute DOMString? autoAriaExpanded;
+    attribute FrozenArray<Element>? autoAriaFlowToElements;
     attribute DOMString? autoAriaHasPopup;
     attribute DOMString? autoAriaHidden;
     attribute DOMString? autoAriaInvalid;
     attribute DOMString? autoAriaKeyShortcuts;
     attribute DOMString? autoAriaLabel;
+    attribute FrozenArray<Element>? autoAriaLabelledByElements;
     attribute DOMString? autoAriaLevel;
     attribute DOMString? autoAriaLive;
     attribute DOMString? autoAriaModal;
     attribute DOMString? autoAriaMultiLine;
     attribute DOMString? autoAriaMultiSelectable;
     attribute DOMString? autoAriaOrientation;
+    attribute FrozenArray<Element>? autoAriaOwnsElements;
     attribute DOMString? autoAriaPlaceholder;
     attribute DOMString? autoAriaPosInSet;
     attribute DOMString? autoAriaPressed;
@@ -137,32 +146,41 @@ The following table provides a correspondence between IDL attribute names and co
 
 <table>
   <tr><th>IDL Attribute</th><th>Reflected AutoARIA Content Attribute</th></tr>
+  <tr><td><dfn>autoRole</dfn></td><td><pref>autorole</pref></td></tr>
+  <tr><td><dfn>autoAriaActiveDescendantElement</dfn></td><td><pref>autoariaactivedescendantelement</pref></td></tr>
   <tr><td><dfn>autoAriaAtomic</dfn></td><td><pref>autoariaatomic</pref></td></tr>
   <tr><td><dfn>autoAriaAutoComplete</dfn></td><td><pref>autoariaautocomplete</pref></td></tr>
-  <tr><td><dfn>autoAriaBusy</dfn></td><td><sref>autoariabusy</sref></td></tr>
-  <tr><td><dfn>autoAriaChecked</dfn></td><td><sref>autoariachecked</sref></td></tr>
+  <tr><td><dfn>autoAriaBusy</dfn></td><td><pref>autoariabusy</pref></td></tr>
+  <tr><td><dfn>autoAriaChecked</dfn></td><td><pref>autoariachecked</pref></td></tr>
   <tr><td><dfn>autoAriaColCount</dfn></td><td><pref>autoariacolcount</pref></td></tr>
   <tr><td><dfn>autoAriaColIndex</dfn></td><td><pref>autoariacolindex</pref></td></tr>
   <tr><td><dfn>autoAriaColIndexText</dfn></td><td><pref>autoariacolindextext</pref></td></tr>
   <tr><td><dfn>autoAriaColSpan</dfn></td><td><pref>autoariacolspan</pref></td></tr>
-  <tr><td><dfn>autoAriaCurrent</dfn></td><td><sref>autoariacurrent</sref></td></tr>
+  <tr><td><dfn>autoAriaControlsElements</dfn></td><td><pref>autoariacontrolselements</pref></td></tr>
+  <tr><td><dfn>autoAriaCurrent</dfn></td><td><pref>autoariacurrent</pref></td></tr>
+  <tr><td><dfn>autoAriaDescribedByElements</dfn></td><td><pref>autoariadescribedbyelements</pref></td></tr>
   <tr><td><dfn>autoAriaDescription</dfn></td><td><pref>autoariadescription</pref></td></tr>
-  <tr><td><dfn>autoAriaDisabled</dfn></td><td><sref>autoariadisabled</sref></td></tr>
-  <tr><td><dfn>autoAriaExpanded</dfn></td><td><sref>autoariaexpanded</sref></td></tr>
+  <tr><td><dfn>autoAriaDetailsElements</dfn></td><td><pref>autoariadetailselements</pref></td></tr>
+  <tr><td><dfn>autoAriaDisabled</dfn></td><td><pref>autoariadisabled</pref></td></tr>
+  <tr><td><dfn>autoAriaErrorMessageElement</dfn></td><td><pref>autoariaerrormessageelement</pref></td></tr>
+  <tr><td><dfn>autoAriaExpanded</dfn></td><td><pref>autoariaexpanded</pref></td></tr>
+  <tr><td><dfn>autoAriaFlowToElements</dfn></td><td><pref>autoariaflowtoelements</pref></td></tr>
   <tr><td><dfn>autoAriaHasPopup</dfn></td><td><pref>autoariahaspopup</pref></td></tr>
-  <tr><td><dfn>autoAriaHidden</dfn></td><td><sref>autoariahidden</sref></td></tr>
-  <tr><td><dfn>autoAriaInvalid</dfn></td><td><sref>autoariainvalid</sref></td></tr>
+  <tr><td><dfn>autoAriaHidden</dfn></td><td><pref>autoariahidden</pref></td></tr>
+  <tr><td><dfn>autoAriaInvalid</dfn></td><td><pref>autoariainvalid</pref></td></tr>
   <tr><td><dfn>autoAriaKeyShortcuts</dfn></td><td><pref>autoariakeyshortcuts</pref></td></tr>
   <tr><td><dfn>autoAriaLabel</dfn></td><td><pref>autoarialabel</pref></td></tr>
+  <tr><td><dfn>autoAriaLabelledByElements</dfn></td><td><pref>autoarialabelledbyelements</pref></td></tr>
   <tr><td><dfn>autoAriaLevel</dfn></td><td><pref>autoarialevel</pref></td></tr>
   <tr><td><dfn>autoAriaLive</dfn></td><td><pref>autoarialive</pref></td></tr>
   <tr><td><dfn>autoAriaModal</dfn></td><td><pref>autoariamodal</pref></td></tr>
   <tr><td><dfn>autoAriaMultiLine</dfn></td><td><pref>autoariamultiline</pref></td></tr>
   <tr><td><dfn>autoAriaMultiSelectable</dfn></td><td><pref>autoariamultiselectable</pref></td></tr>
   <tr><td><dfn>autoAriaOrientation</dfn></td><td><pref>autoariaorientation</pref></td></tr>
+  <tr><td><dfn>autoAriaOwnsElements</dfn></td><td><pref>autoariaownselements</pref></td></tr>
   <tr><td><dfn>autoAriaPlaceholder</dfn></td><td><pref>autoariaplaceholder</pref></td></tr>
   <tr><td><dfn>autoAriaPosInSet</dfn></td><td><pref>autoariaposinset</pref></td></tr>
-  <tr><td><dfn>autoAriaPressed</dfn></td><td><sref>autoariapressed</sref></td></tr>
+  <tr><td><dfn>autoAriaPressed</dfn></td><td><pref>autoariapressed</pref></td></tr>
   <tr><td><dfn>autoAriaReadOnly</dfn></td><td><pref>autoariareadonly</pref></td></tr>
   <tr><td><dfn>autoAriaRequired</dfn></td><td><pref>autoariarequired</pref></td></tr>
   <tr><td><dfn>autoAriaRoleDescription</dfn></td><td><pref>autoariaroledescription</pref></td></tr>
@@ -170,7 +188,7 @@ The following table provides a correspondence between IDL attribute names and co
   <tr><td><dfn>autoAriaRowIndex</dfn></td><td><pref>autoariarowindex</pref></td></tr>
   <tr><td><dfn>autoAriaRowIndexText</dfn></td><td><pref>autoariarowindextext</pref></td></tr>
   <tr><td><dfn>autoAriaRowSpan</dfn></td><td><pref>autoariarowspan</pref></td></tr>
-  <tr><td><dfn>autoAriaSelected</dfn></td><td><sref>autoariaselected</sref></td></tr>
+  <tr><td><dfn>autoAriaSelected</dfn></td><td><pref>autoariaselected</pref></td></tr>
   <tr><td><dfn>autoAriaSetSize</dfn></td><td><pref>autoariasetsize</pref></td></tr>
   <tr><td><dfn>autoAriaSort</dfn></td><td><pref>autoariasort</pref></td></tr>
   <tr><td><dfn>autoAriaValueMax</dfn></td><td><pref>autoariavaluemax</pref></td></tr>
@@ -200,6 +218,8 @@ Note: In practice, this means that, e.g., the `autoAriaAtomic` IDL on `Element` 
 
 <pre class="idl">
   interface mixin ShadowRootMixin {
+    attribute DOMString? delegatesRole;
+    attribute Element? delegatesAriaActiveDescendantElement;
     attribute DOMString? delegatesAriaAtomic;
     attribute DOMString? delegatesAriaAutoComplete;
     attribute DOMString? delegatesAriaBusy;
@@ -208,21 +228,28 @@ Note: In practice, this means that, e.g., the `autoAriaAtomic` IDL on `Element` 
     attribute DOMString? delegatesAriaColIndex;
     attribute DOMString? delegatesAriaColIndexText;
     attribute DOMString? delegatesAriaColSpan;
+    attribute FrozenArray<Element>? delegatesAriaControlsElements;
     attribute DOMString? delegatesAriaCurrent;
+    attribute FrozenArray<Element>? delegatesAriaDescribedByElements;
     attribute DOMString? delegatesAriaDescription;
+    attribute FrozenArray<Element>? delegatesAriaDetailsElements;
     attribute DOMString? delegatesAriaDisabled;
+    attribute Element? delegatesAriaErrorMessageElement;
     attribute DOMString? delegatesAriaExpanded;
+    attribute FrozenArray<Element>? delegatesAriaFlowToElements;
     attribute DOMString? delegatesAriaHasPopup;
     attribute DOMString? delegatesAriaHidden;
     attribute DOMString? delegatesAriaInvalid;
     attribute DOMString? delegatesAriaKeyShortcuts;
     attribute DOMString? delegatesAriaLabel;
+    attribute FrozenArray<Element>? delegatesAriaLabelledByElements;
     attribute DOMString? delegatesAriaLevel;
     attribute DOMString? delegatesAriaLive;
     attribute DOMString? delegatesAriaModal;
     attribute DOMString? delegatesAriaMultiLine;
     attribute DOMString? delegatesAriaMultiSelectable;
     attribute DOMString? delegatesAriaOrientation;
+    attribute FrozenArray<Element>? delegatesAriaOwnsElements;
     attribute DOMString? delegatesAriaPlaceholder;
     attribute DOMString? delegatesAriaPosInSet;
     attribute DOMString? delegatesAriaPressed;
@@ -266,30 +293,37 @@ The following table provides a correspondence between IDL attribute names and co
   <tr><th>IDL Attribute</th><th>Reflected ShadowRoot Content Attribute</th></tr>
   <tr><td><dfn>delegatesAriaAtomic</dfn></td><td><pref>delegatesariaatomic</pref></td></tr>
   <tr><td><dfn>delegatesAriaAutoComplete</dfn></td><td><pref>delegatesariaautocomplete</pref></td></tr>
-  <tr><td><dfn>delegatesAriaBusy</dfn></td><td><sref>delegatesariabusy</sref></td></tr>
-  <tr><td><dfn>delegatesAriaChecked</dfn></td><td><sref>delegatesariachecked</sref></td></tr>
+  <tr><td><dfn>delegatesAriaBusy</dfn></td><td><pref>delegatesariabusy</pref></td></tr>
+  <tr><td><dfn>delegatesAriaChecked</dfn></td><td><pref>delegatesariachecked</pref></td></tr>
   <tr><td><dfn>delegatesAriaColCount</dfn></td><td><pref>delegatesariacolcount</pref></td></tr>
   <tr><td><dfn>delegatesAriaColIndex</dfn></td><td><pref>delegatesariacolindex</pref></td></tr>
   <tr><td><dfn>delegatesAriaColIndexText</dfn></td><td><pref>delegatesariacolindextext</pref></td></tr>
   <tr><td><dfn>delegatesAriaColSpan</dfn></td><td><pref>delegatesariacolspan</pref></td></tr>
-  <tr><td><dfn>delegatesAriaCurrent</dfn></td><td><sref>delegatesariacurrent</sref></td></tr>
+  <tr><td><dfn>delegatesAriaControlsElements</dfn></td><td><pref>delegatesariacontrolselements</pref></td></tr>
+  <tr><td><dfn>delegatesAriaCurrent</dfn></td><td><pref>delegatesariacurrent</pref></td></tr>
+  <tr><td><dfn>delegatesAriaDescribedByElements</dfn></td><td><pref>delegatesariadescribedbyelements</pref></td></tr>
   <tr><td><dfn>delegatesAriaDescription</dfn></td><td><pref>delegatesariadescription</pref></td></tr>
-  <tr><td><dfn>delegatesAriaDisabled</dfn></td><td><sref>delegatesariadisabled</sref></td></tr>
-  <tr><td><dfn>delegatesAriaExpanded</dfn></td><td><sref>delegatesariaexpanded</sref></td></tr>
+  <tr><td><dfn>delegatesAriaDetailsElements</dfn></td><td><pref>delegatesariadetailselements</pref></td></tr>
+  <tr><td><dfn>delegatesAriaDisabled</dfn></td><td><pref>delegatesariadisabled</pref></td></tr>
+  <tr><td><dfn>delegatesAriaErrorMessageElement</dfn></td><td><pref>delegatesariaerrormessageelement</pref></td></tr>
+  <tr><td><dfn>delegatesAriaExpanded</dfn></td><td><pref>delegatesariaexpanded</pref></td></tr>
+  <tr><td><dfn>delegatesAriaFlowToElements</dfn></td><td><pref>delegatesariaflowtoelements</pref></td></tr>
   <tr><td><dfn>delegatesAriaHasPopup</dfn></td><td><pref>delegatesariahaspopup</pref></td></tr>
-  <tr><td><dfn>delegatesAriaHidden</dfn></td><td><sref>delegatesariahidden</sref></td></tr>
-  <tr><td><dfn>delegatesAriaInvalid</dfn></td><td><sref>delegatesariainvalid</sref></td></tr>
+  <tr><td><dfn>delegatesAriaHidden</dfn></td><td><pref>delegatesariahidden</pref></td></tr>
+  <tr><td><dfn>delegatesAriaInvalid</dfn></td><td><pref>delegatesariainvalid</pref></td></tr>
   <tr><td><dfn>delegatesAriaKeyShortcuts</dfn></td><td><pref>delegatesariakeyshortcuts</pref></td></tr>
   <tr><td><dfn>delegatesAriaLabel</dfn></td><td><pref>delegatesarialabel</pref></td></tr>
+  <tr><td><dfn>delegatesAriaLabelledByElements</dfn></td><td><pref>delegatesarialabelledbyelements</pref></td></tr>
   <tr><td><dfn>delegatesAriaLevel</dfn></td><td><pref>delegatesarialevel</pref></td></tr>
   <tr><td><dfn>delegatesAriaLive</dfn></td><td><pref>delegatesarialive</pref></td></tr>
   <tr><td><dfn>delegatesAriaModal</dfn></td><td><pref>delegatesariamodal</pref></td></tr>
   <tr><td><dfn>delegatesAriaMultiLine</dfn></td><td><pref>delegatesariamultiline</pref></td></tr>
   <tr><td><dfn>delegatesAriaMultiSelectable</dfn></td><td><pref>delegatesariamultiselectable</pref></td></tr>
   <tr><td><dfn>delegatesAriaOrientation</dfn></td><td><pref>delegatesariaorientation</pref></td></tr>
+  <tr><td><dfn>delegatesAriaOwnsElements</dfn></td><td><pref>delegatesariaownselements</pref></td></tr>
   <tr><td><dfn>delegatesAriaPlaceholder</dfn></td><td><pref>delegatesariaplaceholder</pref></td></tr>
   <tr><td><dfn>delegatesAriaPosInSet</dfn></td><td><pref>delegatesariaposinset</pref></td></tr>
-  <tr><td><dfn>delegatesAriaPressed</dfn></td><td><sref>delegatesariapressed</sref></td></tr>
+  <tr><td><dfn>delegatesAriaPressed</dfn></td><td><pref>delegatesariapressed</pref></td></tr>
   <tr><td><dfn>delegatesAriaReadOnly</dfn></td><td><pref>delegatesariareadonly</pref></td></tr>
   <tr><td><dfn>delegatesAriaRequired</dfn></td><td><pref>delegatesariarequired</pref></td></tr>
   <tr><td><dfn>delegatesAriaRoleDescription</dfn></td><td><pref>delegatesariaroledescription</pref></td></tr>
@@ -297,7 +331,7 @@ The following table provides a correspondence between IDL attribute names and co
   <tr><td><dfn>delegatesAriaRowIndex</dfn></td><td><pref>delegatesariarowindex</pref></td></tr>
   <tr><td><dfn>delegatesAriaRowIndexText</dfn></td><td><pref>delegatesariarowindextext</pref></td></tr>
   <tr><td><dfn>delegatesAriaRowSpan</dfn></td><td><pref>delegatesariarowspan</pref></td></tr>
-  <tr><td><dfn>delegatesAriaSelected</dfn></td><td><sref>delegatesariaselected</sref></td></tr>
+  <tr><td><dfn>delegatesAriaSelected</dfn></td><td><pref>delegatesariaselected</pref></td></tr>
   <tr><td><dfn>delegatesAriaSetSize</dfn></td><td><pref>delegatesariasetsize</pref></td></tr>
   <tr><td><dfn>delegatesAriaSort</dfn></td><td><pref>delegatesariasort</pref></td></tr>
   <tr><td><dfn>delegatesAriaValueMax</dfn></td><td><pref>delegatesariavaluemax</pref></td></tr>
@@ -326,7 +360,8 @@ Note: In practice, this means that, e.g., the `delegatesAriaAtomic` IDL on `Shad
 <pre class="idl">
   [Exposed=Window]
   dictionary ShadowRootExtInit: ShadowRootInit {
-    boolean delegatesAriaDescribedBy = false;
+    boolean delegatesRole = false;
+    boolean delegatesAriaActiveDescendantElement = false;
     boolean delegatesAriaAtomic = false;
     boolean delegatesAriaAutoComplete = false;
     boolean delegatesAriaBusy = false;
@@ -335,21 +370,28 @@ Note: In practice, this means that, e.g., the `delegatesAriaAtomic` IDL on `Shad
     boolean delegatesAriaColIndex = false;
     boolean delegatesAriaColIndexText = false;
     boolean delegatesAriaColSpan = false;
+    boolean delegatesAriaControlsElements = false;
     boolean delegatesAriaCurrent = false;
+    boolean delegatesAriaDescribedByElements = false;
     boolean delegatesAriaDescription = false;
+    boolean delegatesAriaDetailsElements = false;
     boolean delegatesAriaDisabled = false;
+    boolean delegatesAriaErrorMessageElement = false;
     boolean delegatesAriaExpanded = false;
+    boolean delegatesAriaFlowToElements = false;
     boolean delegatesAriaHasPopup = false;
     boolean delegatesAriaHidden = false;
     boolean delegatesAriaInvalid = false;
     boolean delegatesAriaKeyShortcuts = false;
     boolean delegatesAriaLabel = false;
+    boolean delegatesAriaLabelledByElements = false;
     boolean delegatesAriaLevel = false;
     boolean delegatesAriaLive = false;
     boolean delegatesAriaModal = false;
     boolean delegatesAriaMultiLine = false;
     boolean delegatesAriaMultiSelectable = false;
     boolean delegatesAriaOrientation = false;
+    boolean delegatesAriaOwnsElements = false;
     boolean delegatesAriaPlaceholder = false;
     boolean delegatesAriaPosInSet = false;
     boolean delegatesAriaPressed = false;
@@ -397,7 +439,8 @@ User agents MUST update the attachShadow method signature in the <code>Element</
     <tr><th>Attribute</th><th>Delegates</th></tr>
   </thead>
   <tbody>
-    <tr><td>delegates ariaDescribedBy</td><td>delegatesAriaDescribedBy</td></tr>
+    <tr><td>delegates role</td><td>delegatesRole</td></tr>
+    <tr><td>delegates ariaActiveDescendantElement</td><td>delegatesAriaActiveDescendantElement</td></tr>
     <tr><td>delegates ariaAtomic</td><td>delegatesAriaAtomic</td></tr>
     <tr><td>delegates ariaAutoComplete</td><td>delegatesAriaAutoComplete</td></tr>
     <tr><td>delegates ariaBusy</td><td>delegatesAriaBusy</td></tr>
@@ -406,21 +449,28 @@ User agents MUST update the attachShadow method signature in the <code>Element</
     <tr><td>delegates ariaColIndex</td><td>delegatesAriaColIndex</td></tr>
     <tr><td>delegates ariaColIndexText</td><td>delegatesAriaColIndexText</td></tr>
     <tr><td>delegates ariaColSpan</td><td>delegatesAriaColSpan</td></tr>
+    <tr><td>delegates ariaControlsElements</td><td>delegatesAriaControlsElements</td></tr>
     <tr><td>delegates ariaCurrent</td><td>delegatesAriaCurrent</td></tr>
+    <tr><td>delegates ariaDescribedByElements</td><td>delegatesAriaDescribedByElements</td></tr>
     <tr><td>delegates ariaDescription</td><td>delegatesAriaDescription</td></tr>
+    <tr><td>delegates ariaDetailsElements</td><td>delegatesAriaDetailsElements</td></tr>
     <tr><td>delegates ariaDisabled</td><td>delegatesAriaDisabled</td></tr>
+    <tr><td>delegates ariaErrorMessageElement</td><td>delegatesAriaErrorMessageElement</td></tr>
     <tr><td>delegates ariaExpanded</td><td>delegatesAriaExpanded</td></tr>
+    <tr><td>delegates ariaFlowToElements</td><td>delegatesAriaFlowToElements</td></tr>
     <tr><td>delegates ariaHasPopup</td><td>delegatesAriaHasPopup</td></tr>
     <tr><td>delegates ariaHidden</td><td>delegatesAriaHidden</td></tr>
     <tr><td>delegates ariaInvalid</td><td>delegatesAriaInvalid</td></tr>
     <tr><td>delegates ariaKeyShortcuts</td><td>delegatesAriaKeyShortcuts</td></tr>
     <tr><td>delegates ariaLabel</td><td>delegatesAriaLabel</td></tr>
+    <tr><td>delegates ariaLabelledByElements</td><td>delegatesAriaLabelledByElements</td></tr>
     <tr><td>delegates ariaLevel</td><td>delegatesAriaLevel</td></tr>
     <tr><td>delegates ariaLive</td><td>delegatesAriaLive</td></tr>
     <tr><td>delegates ariaModal</td><td>delegatesAriaModal</td></tr>
     <tr><td>delegates ariaMultiLine</td><td>delegatesAriaMultiLine</td></tr>
     <tr><td>delegates ariaMultiSelectable</td><td>delegatesAriaMultiSelectable</td></tr>
     <tr><td>delegates ariaOrientation</td><td>delegatesAriaOrientation</td></tr>
+    <tr><td>delegates ariaOwnsElements</td><td>delegatesAriaOwnsElements</td></tr>
     <tr><td>delegates ariaPlaceholder</td><td>delegatesAriaPlaceholder</td></tr>
     <tr><td>delegates ariaPosInSet</td><td>delegatesAriaPosInSet</td></tr>
     <tr><td>delegates ariaPressed</td><td>delegatesAriaPressed</td></tr>


### PR DESCRIPTION
Fixes #10

This adds all attributes from [the current `ARIAMixin`](https://w3c.github.io/aria/#ARIAMixin). It includes `aria-*` as well as `role`.