### PR TITLE
Add SVG `<use>` and `@font-face` as other use cases

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -332,8 +332,8 @@ Here we cannot set the relationship between the external `label` and the inner `
 There are other cases that also reference to other elements:
 * [`list`](https://html.spec.whatwg.org/multipage/input.html#attr-input-list) attribute in `input`.
 * [Pop Up](https://open-ui.org/components/popup.research.explainer) proposal by Open UI, that adds some new attributes `popuptoggletarget`, `popupshowtarget` and `popuphidetarget`.
-* [SVG `<use>`](https://github.com/WICG/webcomponents/issues/772)
-* [`@font-face`](https://robdodson.me/posts/at-font-face-doesnt-work-in-shadow-dom/)
+* [SVG `<use>` and the `href` attribute](https://github.com/WICG/webcomponents/issues/772)
+* [`@font-face` and the `font-family` CSS property](https://robdodson.me/posts/at-font-face-doesnt-work-in-shadow-dom/)
 
 Should we look for a solution that is generic enough to cover these cases too?
 

--- a/explainer.md
+++ b/explainer.md
@@ -332,6 +332,8 @@ Here we cannot set the relationship between the external `label` and the inner `
 There are other cases that also reference to other elements:
 * [`list`](https://html.spec.whatwg.org/multipage/input.html#attr-input-list) attribute in `input`.
 * [Pop Up](https://open-ui.org/components/popup.research.explainer) proposal by Open UI, that adds some new attributes `popuptoggletarget`, `popupshowtarget` and `popuphidetarget`.
+* [SVG `<use>`](https://github.com/WICG/webcomponents/issues/772)
+* [`@font-face`](https://robdodson.me/posts/at-font-face-doesnt-work-in-shadow-dom/)
 
 Should we look for a solution that is generic enough to cover these cases too?
 


### PR DESCRIPTION
I recently realized that SVG `<use>` `href` references cannot cross shadow boundaries: https://github.com/WICG/webcomponents/issues/772

Additionally, `@font-face`'s `font-family` cannot be used across shadow boundaries either: https://robdodson.me/posts/at-font-face-doesnt-work-in-shadow-dom/ (Ahis post discusses the fact that it doesn't even work within the same shadow root, but that's a browser bug. In any case, it can't be referenced across shadow roots.)

I think it's worth calling out any cross-root use cases we can think of, just to consider if we can solve those at the same time.